### PR TITLE
Replace FastAPI example with FastMCP time server

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,43 @@
-from fastapi import FastAPI
+"""Streamable HTTP MCP server providing current time information."""
+from __future__ import annotations
 
-app = FastAPI()
+from datetime import datetime, timezone
+from typing import Optional
 
-@app.get("/")
-async def root():
-    return {"greeting": "Hello, World!", "message": "Welcome to FastAPI!"}
+from fastmcp import FastMCP
+from fastmcp.adapters.streamable_http import StreamableHTTPServer
+from zoneinfo import ZoneInfo
+
+mcp = FastMCP(
+    name="time-mcp-server",
+    version="1.0.0",
+    description="Simple MCP server that returns the current time.",
+)
+
+
+@mcp.tool(name="current_time", description="Get the current time optionally in a specific timezone.")
+async def current_time(timezone_name: Optional[str] = None) -> dict[str, str]:
+    """Return the current time as an ISO formatted string.
+
+    Args:
+        timezone_name: Optional IANA timezone identifier (e.g. "Europe/Berlin").
+
+    Returns:
+        A dictionary containing the resolved timezone and current time.
+    """
+
+    tz = timezone.utc
+    tz_label = "UTC"
+
+    if timezone_name:
+        try:
+            tz = ZoneInfo(timezone_name)
+            tz_label = timezone_name
+        except Exception as exc:  # pragma: no cover - defensive path
+            raise ValueError(f"Unknown timezone: {timezone_name}") from exc
+
+    now = datetime.now(tz)
+    return {"timezone": tz_label, "iso_time": now.isoformat()}
+
+
+app = StreamableHTTPServer(mcp).app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-fastapi==0.100.0
-hypercorn==0.14.4
+fastmcp>=0.1.0
+uvicorn>=0.23.0


### PR DESCRIPTION
## Summary
- replace the FastAPI demo endpoint with a FastMCP-powered time server that exposes a streamable HTTP interface
- update runtime dependencies to use fastmcp and uvicorn for deployment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d66992f7f88325a08b9d6cfbf53f13