### PR TITLE
Switch FastMCP server to HTTP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,32 @@
----
-title: FastAPI
-description: A FastAPI server
-tags:
-  - fastapi
-  - hypercorn
-  - python
----
+# FastMCP HTTP Time Server
 
-# FastAPI Example
+Dieses Repository stellt einen minimalen [FastMCP](https://gofastmcp.com/) Server bereit,
+der über den HTTP (Streamable) Transport die aktuelle Uhrzeit als Tool anbietet. Die App ist
+bereit für Railway-Deployments, funktioniert aber ebenso lokal.
 
-This example starts up a [FastAPI](https://fastapi.tiangolo.com/) server.
+## 🚀 Setup
 
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/-NvLj4?referralCode=CRJ8FE)
-## ✨ Features
+```bash
+pip install -r requirements.txt
+```
 
-- FastAPI
-- [Hypercorn](https://hypercorn.readthedocs.io/)
-- Python 3
+## ▶️ Startbefehle
 
-## 💁‍♀️ How to use
+- Produktion (Railway o. Ä.):
+  ```bash
+  uvicorn main:app --host 0.0.0.0 --port 8000
+  ```
+- Lokal als Skript mit integriertem Server:
+  ```bash
+  python main.py
+  ```
 
-- Clone locally and install packages with pip using `pip install -r requirements.txt`
-- Run locally using `hypercorn main:app --reload`
+## 🛠️ Tooling
 
-## 📝 Notes
+Der Server registriert ein einziges Tool `current_time`, welches den aktuellen UTC-Zeitstempel
+im ISO-8601-Format zurückgibt.
 
-- To learn about how to use FastAPI with most of its features, you can visit the [FastAPI Documentation](https://fastapi.tiangolo.com/tutorial/)
-- To learn about Hypercorn and how to configure it, read their [Documentation](https://hypercorn.readthedocs.io/)
+## 📚 Ressourcen
+
+- FastMCP Dokumentation: https://gofastmcp.com/
+- Streamable HTTP Deployment Guide: https://gofastmcp.com/deployment/running-server

--- a/main.py
+++ b/main.py
@@ -1,7 +1,24 @@
-from fastapi import FastAPI
+"""FastMCP time server ready for HTTP deployments."""
+from __future__ import annotations
 
-app = FastAPI()
+from datetime import datetime, timezone
 
-@app.get("/")
-async def root():
-    return {"greeting": "Hello, World!", "message": "Welcome to FastAPI!"}
+from fastmcp import FastMCP
+
+mcp = FastMCP("time-mcp-server")
+
+
+@mcp.tool(description="Gibt die aktuelle Zeit im ISO-8601-Format zurück.")
+def current_time() -> str:
+    """Return the current UTC time as an ISO formatted string."""
+
+    return datetime.now(timezone.utc).isoformat()
+
+
+# The ASGI app Railway (or any other platform) can serve via Uvicorn/Hypercorn.
+app = mcp.http_app()
+
+
+if __name__ == "__main__":
+    # Run the HTTP transport directly for local testing.
+    mcp.run(transport="http", host="0.0.0.0", port=8000)

--- a/railway.json
+++ b/railway.json
@@ -4,6 +4,6 @@
     "builder": "NIXPACKS"
   },
   "deploy": {
-    "startCommand": "hypercorn main:app --bind \"[::]:$PORT\""
+    "startCommand": "uvicorn main:app --host 0.0.0.0 --port $PORT"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-fastapi==0.100.0
-hypercorn==0.14.4
+fastmcp[http]>=2.12.3
+uvicorn>=0.23.0


### PR DESCRIPTION
## Summary
- change the FastMCP ASGI app and run helper to use the documented HTTP transport while keeping the deployment entry point intact
- refresh the README wording to reflect the HTTP transport terminology

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68d66992f7f88325a08b9d6cfbf53f13